### PR TITLE
Fixed open bug

### DIFF
--- a/extract_android_ota_payload.py
+++ b/extract_android_ota_payload.py
@@ -115,7 +115,9 @@ def main(argv):
     output_dir = argv[2]
   except IndexError:
     output_dir = os.getcwd()
-
+  
+  if not os.path.exists(output_dir):
+    os.makedirs(output_dir)
   if filename.endswith('.zip'):
     print("Extracting 'payload.bin' from OTA file...")
     ota_zf = zipfile.ZipFile(filename)


### PR DESCRIPTION
If the user gives a path that does not exist and must be created, open(file, output_dir) fails.
I've fixed the problem with 2 additional lines.
I think it is worth to merge.