### PR TITLE
Add full update_metadata package URL for clarity

### DIFF
--- a/extract_android_ota_payload.py
+++ b/extract_android_ota_payload.py
@@ -13,7 +13,7 @@ import zipfile
 if sys.version_info[0] != 2:
   raise Exception("Python 2.x is required")
 
-# from https://android.googlesource.com/platform/system/update_engine/scripts/
+# from https://android.googlesource.com/platform/system/update_engine/+/refs/heads/master/scripts/update_payload/
 import update_metadata_pb2
 
 PROGRAMS = [ 'bzcat', 'xzcat' ]


### PR DESCRIPTION
Just a quick change so that others won't fall into the same navigational trap that I did while trying to find the original source. 